### PR TITLE
new minunit.h with counter for each test suit; new output separated b…

### DIFF
--- a/tests/minunit.h
+++ b/tests/minunit.h
@@ -67,6 +67,12 @@
 #include <math.h>
 
 /*  Print with colors */
+	// in case you come across the following error, 
+		// error: ‘%s’ directive output may be truncated writing up to 
+		// 10000 bytes into a region of size 940 [-Werror=format-truncation=]
+	// add the following flag to cc/gcc:
+		// -Wno-format-truncation
+	// as https://github.com/apple/cups/issues/5110
 #define PRINTRED(X)     "\033[31m"X"\033[0m"            /* Red */
 #define PRINTGRN(X)     "\033[32m"X"\033[0m"            /* Green */
 #define BOLDRED(X)      "\033[1m\033[31m"X"\033[0m"     /* Bold Red */
@@ -78,6 +84,7 @@
 #define MINUNIT_EPSILON 1E-12
 
 /*  Misc. counters */
+static int minunit_suit = 0;
 static int minunit_run = 0;
 static int minunit_assert = 0;
 static int minunit_fail = 0;
@@ -104,6 +111,8 @@ static void (*minunit_teardown)(void) = NULL;
 
 /*  Run test suite and unset setup and teardown functions */
 #define MU_RUN_SUITE(suite_name) MU__SAFE_BLOCK(\
+	minunit_suit++;\
+	printf("Test Suit %d:", minunit_suit);\
 	suite_name();\
 	minunit_setup = NULL;\
 	minunit_teardown = NULL;\
@@ -123,11 +132,12 @@ static void (*minunit_teardown)(void) = NULL;
 	}\
 	if (minunit_setup) (*minunit_setup)();\
 	minunit_status = 0;\
+	printf("\n%d:", minunit_run + 1);\
 	test();\
 	minunit_run++;\
 	if (minunit_status) {\
 		minunit_fail++;\
-		printf(BOLDRED("F"));\
+		printf(BOLDRED(" KO! "));\
 		printf("\n%s\n", minunit_last_message);\
 	}\
 	fflush(stdout);\
@@ -158,7 +168,7 @@ static void (*minunit_teardown)(void) = NULL;
 		minunit_status = 1;\
 		return;\
 	} else {\
-		printf(BOLDGREEN("."));\
+		printf(BOLDGREEN(" OK "));\
 	}\
 )
 
@@ -176,7 +186,7 @@ static void (*minunit_teardown)(void) = NULL;
 		minunit_status = 1;\
 		return;\
 	} else {\
-		printf(BOLDGREEN("."));\
+		printf(BOLDGREEN(" OK "));\
 	}\
 )
 
@@ -191,7 +201,7 @@ static void (*minunit_teardown)(void) = NULL;
 		minunit_status = 1;\
 		return;\
 	} else {\
-		printf(BOLDGREEN("."));\
+		printf(BOLDGREEN(" OK "));\
 	}\
 )
 
@@ -207,7 +217,7 @@ static void (*minunit_teardown)(void) = NULL;
 		minunit_status = 1;\
 		return;\
 	} else {\
-		printf(BOLDGREEN("."));\
+		printf(BOLDGREEN(" OK "));\
 	}\
 )
 
@@ -224,12 +234,11 @@ static void (*minunit_teardown)(void) = NULL;
 	if(strcmp(minunit_tmp_e, minunit_tmp_r)) {\
 		snprintf(minunit_last_message, MINUNIT_MESSAGE_LEN, PRINTRED("%s failed:\n\t%s:%d: '%s' expected but was '%s'"), __func__, __FILE__, __LINE__, minunit_tmp_e, minunit_tmp_r);\
 		minunit_status = 1;\
-		return;\
-	} else {\
-		printf(BOLDGREEN("."));\
+		return;}\
+	else {\
+		printf(BOLDGREEN(" OK "));\
 	}\
 )
-
 /*
  * The following two functions were written by David Robert Nadeau
  * from http://NadeauSoftware.com/ and distributed under the


### PR DESCRIPTION
…y test suit number and test number, each test on one separate line; replaced '.' for 'OK' and 'F' for 'KO\!' on output.

Galera, este pull request é para algumas alterações que fiz no minunit.h. Troquei '.' por 'OK' e 'F' por 'KO!'. Além disso, adicionei um contador para cada "suit" de testes. Assim, é possível organizar o output para cada pacote de testes que queremos fazer. 
Digamos, por exemplo, que queiramos fazer uma bateria de testes para o bonus do libft. Isso pode ser feito com fazer um bloco no minunit.c  chamado MU_TEST_SUITE(test_suite_bonus), onde vamos colocar os testes para os bonus. Se o seu arquivo de teste tiver 4 suits, com 3 testes em cada, e 2 asserts por test. Assim, o output sera algo do tipo:
test_suit1:
1. OK  OK 
2. OK  KO!
           aqui vai mensagem detalhando o erro de acordo com implementacao do teste...

3. OK  OK

test_suit2:
1. OK  OK 
... e assim vai.

Um detalhe... após as alterações, obtive um erro de complicação de devido à flag -Werror e o uso da função snprintf. Após pesquisar, entendi que este erro é benigno e pode ser ignorado. Para isso, basta incluir a flag _**-Wno-format-truncation**_ às outras flags que já usamos. 

cc -Wall -Wextra -Werror -Wno-format-truncation ...

Qualquer coisa estranha, avisem para a gente corrigir.

Paz e bons códigos!
